### PR TITLE
Make directory with parent directories

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -63,6 +63,7 @@ Possible answers to your issue
 - version: `v`
 - available RAM: `GB`
 - Docker version: `v`
+- docker-compose version: `v`
 
 ### Environment Variables
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     domainname: ${DOMAINNAME}
     container_name: ${CONTAINER_NAME}
     env_file: mailserver.env
+    # To avoid conflicts with yaml base-60 float, DO NOT remove the quotation marks.
     ports:
       - "25:25"
       - "143:143"

--- a/target/bin/generate-ssl-certificate
+++ b/target/bin/generate-ssl-certificate
@@ -14,7 +14,7 @@ SSL_CFG_PATH="/tmp/docker-mailserver/ssl"
 
 if [[ ! -d ${SSL_CFG_PATH} ]]
 then
-  mkdir "${SSL_CFG_PATH}"
+  mkdir --parents "${SSL_CFG_PATH}"
 fi
 
 cd "${SSL_CFG_PATH}" || { echo "cd ${SSL_CFG_PATH} error" ; exit ; }


### PR DESCRIPTION
If you don't mount the ssl directory or set SSL_CFG_PATH to something else then the directory needs to be created with parents.